### PR TITLE
Add MaxRestartTime to BGPPeerSpec (used to BGP graceful restart timer)

### DIFF
--- a/pkg/apis/projectcalico/v3/bgppeer.go
+++ b/pkg/apis/projectcalico/v3/bgppeer.go
@@ -93,6 +93,9 @@ type BGPPeerSpec struct {
 	// this BGPPeer resource.  Default value "UseNodeIP" means to configure the node IP as the
 	// source address.  "None" means not to configure a source address.
 	SourceAddress SourceAddress `json:"sourceAddress,omitempty" validate:"omitempty,sourceAddress"`
+	// Time to allow for software restart.  When specified, this is configured as the graceful
+	// restart timeout.  When not specified, the BIRD default of 120s is used.
+	MaxRestartTime *metav1.Duration `json:"maxRestartTime,omitempty"`
 }
 
 type SourceAddress string

--- a/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -232,6 +232,11 @@ func (in *BGPPeerSpec) DeepCopyInto(out *BGPPeerSpec) {
 		*out = new(BGPPassword)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.MaxRestartTime != nil {
+		in, out := &in.MaxRestartTime, &out.MaxRestartTime
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -761,11 +761,17 @@ func schema_pkg_apis_projectcalico_v3_BGPPeerSpec(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"maxRestartTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Time to allow for software restart.  When specified, this is configured as the graceful restart timeout.  When not specified, the BIRD defaults of 120s is used.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/projectcalico/api/pkg/apis/projectcalico/v3.BGPPassword"},
+			"github.com/projectcalico/api/pkg/apis/projectcalico/v3.BGPPassword", "k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Add the field MaxRestartTime (Duration) to BGPPeerSpec. This is going to be used to configure the BGP graceful restart timer on BIRD.

## Todos
- [ ] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Added MaxRestartTime to BGPPeerSpec (used for BIRD's BGP graceful restart configuration)
```
