### PR TITLE
Override OpenAPI definition for Port, Protocol and Uint8OrString

### DIFF
--- a/pkg/lib/numorstring/openapi_generated.go
+++ b/pkg/lib/numorstring/openapi_generated.go
@@ -9,7 +9,7 @@
 package numorstring
 
 import (
-	spec "github.com/go-openapi/spec"
+	"github.com/go-openapi/spec"
 	common "k8s.io/kube-openapi/pkg/common"
 )
 
@@ -26,29 +26,8 @@ func schema_api_pkg_lib_numorstring_Port(ref common.ReferenceCallback) common.Op
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Port represents either a range of numeric ports or a named port.\n\n    - For a named port, set the PortName, leaving MinPort and MaxPort as 0.\n    - For a port range, set MinPort and MaxPort to the (inclusive) port numbers.  Set\n      PortName to \"\".\n    - For a single port, set MinPort = MaxPort and PortName = \"\".",
-				Type:        []string{"object"},
-				Properties: map[string]spec.Schema{
-					"minPort": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
-						},
-					},
-					"maxPort": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
-						},
-					},
-					"portName": {
-						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
-					},
-				},
-				Required: []string{"portName"},
+				Type:        Port{}.OpenAPISchemaType(),
+				Format:      Port{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -58,31 +37,8 @@ func schema_api_pkg_lib_numorstring_Protocol(ref common.ReferenceCallback) commo
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
-				Properties: map[string]spec.Schema{
-					"type": {
-						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "int32",
-						},
-					},
-					"numVal": {
-						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "byte",
-						},
-					},
-					"strVal": {
-						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
-					},
-				},
-				Required: []string{"type", "numVal", "strVal"},
+				Type:   Protocol{}.OpenAPISchemaType(),
+				Format: Protocol{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -93,31 +49,8 @@ func schema_api_pkg_lib_numorstring_Uint8OrString(ref common.ReferenceCallback) 
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "UInt8OrString is a type that can hold an uint8 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
-				Type:        []string{"object"},
-				Properties: map[string]spec.Schema{
-					"type": {
-						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "int32",
-						},
-					},
-					"numVal": {
-						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "byte",
-						},
-					},
-					"strVal": {
-						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
-					},
-				},
-				Required: []string{"type", "numVal", "strVal"},
+				Type:        Uint8OrString{}.OpenAPISchemaType(),
+				Format:      Uint8OrString{}.OpenAPISchemaFormat(),
 			},
 		},
 	}

--- a/pkg/lib/numorstring/port.go
+++ b/pkg/lib/numorstring/port.go
@@ -142,3 +142,13 @@ func (p Port) String() string {
 		return fmt.Sprintf("%d:%d", p.MinPort, p.MaxPort)
 	}
 }
+
+// OpenAPISchemaType is used by the kube-openapi generator when constructing
+// the OpenAPI spec of this type.
+// See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
+func (_ Port) OpenAPISchemaType() []string { return []string{"string"} }
+
+// OpenAPISchemaFormat is used by the kube-openapi generator when constructing
+// the OpenAPI spec of this type.
+// See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
+func (_ Port) OpenAPISchemaFormat() string { return "int-or-string" }

--- a/pkg/lib/numorstring/protocol.go
+++ b/pkg/lib/numorstring/protocol.go
@@ -133,3 +133,13 @@ func (p Protocol) SupportsPorts() bool {
 		return false
 	}
 }
+
+// OpenAPISchemaType is used by the kube-openapi generator when constructing
+// the OpenAPI spec of this type.
+// See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
+func (_ Protocol) OpenAPISchemaType() []string { return []string{"string"} }
+
+// OpenAPISchemaFormat is used by the kube-openapi generator when constructing
+// the OpenAPI spec of this type.
+// See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
+func (_ Protocol) OpenAPISchemaFormat() string { return "int-or-string" }

--- a/pkg/lib/numorstring/uint8orstring.go
+++ b/pkg/lib/numorstring/uint8orstring.go
@@ -78,3 +78,13 @@ func (i Uint8OrString) NumValue() (uint8, error) {
 	}
 	return i.NumVal, nil
 }
+
+// OpenAPISchemaType is used by the kube-openapi generator when constructing
+// the OpenAPI spec of this type.
+// See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
+func (_ Uint8OrString) OpenAPISchemaType() []string { return []string{"string"} }
+
+// OpenAPISchemaFormat is used by the kube-openapi generator when constructing
+// the OpenAPI spec of this type.
+// See: https://github.com/kubernetes/kube-openapi/tree/master/pkg/generators
+func (_ Uint8OrString) OpenAPISchemaFormat() string { return "int-or-string" }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -13,6 +13,8 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 	common "k8s.io/kube-openapi/pkg/common"
+
+	numorstring "github.com/projectcalico/api/pkg/lib/numorstring"
 )
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
@@ -3714,29 +3716,8 @@ func schema_api_pkg_lib_numorstring_Port(ref common.ReferenceCallback) common.Op
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Port represents either a range of numeric ports or a named port.\n\n    - For a named port, set the PortName, leaving MinPort and MaxPort as 0.\n    - For a port range, set MinPort and MaxPort to the (inclusive) port numbers.  Set\n      PortName to \"\".\n    - For a single port, set MinPort = MaxPort and PortName = \"\".",
-				Type:        []string{"object"},
-				Properties: map[string]spec.Schema{
-					"minPort": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
-						},
-					},
-					"maxPort": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
-						},
-					},
-					"portName": {
-						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
-					},
-				},
-				Required: []string{"portName"},
+				Type:        numorstring.Port{}.OpenAPISchemaType(),
+				Format:      numorstring.Port{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -3746,31 +3727,8 @@ func schema_api_pkg_lib_numorstring_Protocol(ref common.ReferenceCallback) commo
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
-				Properties: map[string]spec.Schema{
-					"type": {
-						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "int32",
-						},
-					},
-					"numVal": {
-						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "byte",
-						},
-					},
-					"strVal": {
-						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
-					},
-				},
-				Required: []string{"type", "numVal", "strVal"},
+				Type:   numorstring.Protocol{}.OpenAPISchemaType(),
+				Format: numorstring.Protocol{}.OpenAPISchemaFormat(),
 			},
 		},
 	}
@@ -3781,31 +3739,8 @@ func schema_api_pkg_lib_numorstring_Uint8OrString(ref common.ReferenceCallback) 
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "UInt8OrString is a type that can hold an uint8 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
-				Type:        []string{"object"},
-				Properties: map[string]spec.Schema{
-					"type": {
-						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "int32",
-						},
-					},
-					"numVal": {
-						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "byte",
-						},
-					},
-					"strVal": {
-						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
-					},
-				},
-				Required: []string{"type", "numVal", "strVal"},
+				Type:        numorstring.Uint8OrString{}.OpenAPISchemaType(),
+				Format:      numorstring.Uint8OrString{}.OpenAPISchemaFormat(),
 			},
 		},
 	}


### PR DESCRIPTION
## Description

This PR adds overrides to the OpenAPI definitions for Port, Protocol and Uint8OrString in numorstring according to: https://github.com/kubernetes/kube-openapi/tree/release-1.18/pkg/generators#custom-openapi-type-definitions
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
