### PR TITLE
Add support for HostPorts

### DIFF
--- a/pkg/apis/projectcalico/v3/hostendpoint.go
+++ b/pkg/apis/projectcalico/v3/hostendpoint.go
@@ -88,6 +88,8 @@ type EndpointPort struct {
 	Name     string               `json:"name" validate:"portName"`
 	Protocol numorstring.Protocol `json:"protocol"`
 	Port     uint16               `json:"port" validate:"gt=0"`
+	HostPort uint16               `json:"hostPort"`
+	HostIP   string               `json:"hostIP"`
 }
 
 // NewHostEndpoint creates a new (zeroed) HostEndpoint struct with the TypeMetadata initialised to the current


### PR DESCRIPTION
## Description
This adds HostPort / HostIP fields in the EndpointPort struct to prepare HostPort support.
Regarding testing, will the tests related to this feature in the other repos be suficient or do you think we should add some tests in this repo as well?

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
