### PR TITLE
Register resources with the internal version.

### DIFF
--- a/pkg/apis/projectcalico/v3/register.go
+++ b/pkg/apis/projectcalico/v3/register.go
@@ -13,6 +13,7 @@ const GroupName = "projectcalico.org"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v3"}
+var SchemeGroupVersionInternal = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
 
 var (
 	SchemeBuilder      runtime.SchemeBuilder
@@ -29,7 +30,7 @@ func init() {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	all := []runtime.Object{
 		&NetworkPolicy{},
 		&NetworkPolicyList{},
 		&GlobalNetworkPolicy{},
@@ -54,8 +55,13 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ClusterInformationList{},
 		&NetworkSet{},
 		&NetworkSetList{},
-	)
+	}
+	scheme.AddKnownTypes(SchemeGroupVersion, all...)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+
+	// At the moment the v3 API is identical to the internal API. Register the same set of definitions as the
+	// internal set, no conversions are required since they are identical.
+	scheme.AddKnownTypes(SchemeGroupVersionInternal, all...)
 	return nil
 }
 


### PR DESCRIPTION
## Description
I believe this fixes the issues with patches not working correctly.

Doesn't seem like we need separate internal structs nor conversions between the internal and external APIs.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
