### PR TITLE
Move registering internal group to clients that need it

### DIFF
--- a/pkg/apis/projectcalico/v3/register.go
+++ b/pkg/apis/projectcalico/v3/register.go
@@ -19,18 +19,7 @@ var (
 	SchemeBuilder      runtime.SchemeBuilder
 	localSchemeBuilder = &SchemeBuilder
 	AddToScheme        = localSchemeBuilder.AddToScheme
-)
-
-func init() {
-	// We only register manually written functions here. The registration of the
-	// generated functions takes place in the generated files. The separation
-	// makes the code compile even when the generated files are missing.
-	localSchemeBuilder.Register(addKnownTypes, addConversionFuncs)
-}
-
-// Adds the list of known types to api.Scheme.
-func addKnownTypes(scheme *runtime.Scheme) error {
-	all := []runtime.Object{
+	AllKnownTypes      = []runtime.Object{
 		&NetworkPolicy{},
 		&NetworkPolicyList{},
 		&GlobalNetworkPolicy{},
@@ -56,12 +45,19 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&NetworkSet{},
 		&NetworkSetList{},
 	}
-	scheme.AddKnownTypes(SchemeGroupVersion, all...)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+)
 
-	// At the moment the v3 API is identical to the internal API. Register the same set of definitions as the
-	// internal set, no conversions are required since they are identical.
-	scheme.AddKnownTypes(SchemeGroupVersionInternal, all...)
+func init() {
+	// We only register manually written functions here. The registration of the
+	// generated functions takes place in the generated files. The separation
+	// makes the code compile even when the generated files are missing.
+	localSchemeBuilder.Register(addKnownTypes, addConversionFuncs)
+}
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion, AllKnownTypes...)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }
 


### PR DESCRIPTION
## Description

Move registration of resource types as internal to clients that need it. 

Registering resource types as v3 and internal is causing error in some clients, for instance while creating client in tigera-operator it throws error
`"multiple group-version-kinds associated with type *v3.LicenseKey, refusing to guess at one"` and the values causing it are

```
0 = {k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind} 
 Group = {string} "projectcalico.org"
 Version = {string} "v3"
 Kind = {string} "LicenseKey"
1 = {k8s.io/apimachinery/pkg/runtime/schema.GroupVersionKind} 
 Group = {string} "projectcalico.org"
 Version = {string} "__internal"
 Kind = {string} "LicenseKey"
```

Move registering resource as internal to apisever that needs it 
https://github.com/projectcalico/apiserver/pull/56

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
