### PR TITLE
[allowed-use] Add allowed uses field to IP Pool.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,7 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/apis/projectcalico/v3/ippool.go
+++ b/pkg/apis/projectcalico/v3/ippool.go
@@ -87,8 +87,8 @@ type IPPoolSpec struct {
 type IPPoolAllowedUse string
 
 const (
-	IPPoolAllowedUseWorkload      IPPoolAllowedUse = "Workload"
-	IPPoolAllowedUseTunnel                         = "Tunnel"
+	IPPoolAllowedUseWorkload IPPoolAllowedUse = "Workload"
+	IPPoolAllowedUseTunnel                    = "Tunnel"
 )
 
 type VXLANMode string

--- a/pkg/apis/projectcalico/v3/ippool.go
+++ b/pkg/apis/projectcalico/v3/ippool.go
@@ -78,7 +78,18 @@ type IPPoolSpec struct {
 	// Deprecated: this field is only used for APIv1 backwards compatibility.
 	// Setting this field is not allowed, this field is for internal use only.
 	NATOutgoingV1 bool `json:"nat-outgoing,omitempty" validate:"omitempty,mustBeFalse"`
+
+	// AllowedUse controls what the IP pool will be used for.  If not specified or empty, defaults to
+	// ["Tunnel", "Workload"] for back-compatibility
+	AllowedUses []IPPoolAllowedUse `json:"allowedUses,omitempty" validate:"omitempty"`
 }
+
+type IPPoolAllowedUse string
+
+const (
+	IPPoolAllowedUseWorkload      IPPoolAllowedUse = "Workload"
+	IPPoolAllowedUseTunnel                         = "Tunnel"
+)
 
 type VXLANMode string
 

--- a/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
+++ b/pkg/apis/projectcalico/v3/zz_generated.deepcopy.go
@@ -1297,6 +1297,11 @@ func (in *IPPoolSpec) DeepCopyInto(out *IPPoolSpec) {
 		*out = new(IPIPConfiguration)
 		**out = **in
 	}
+	if in.AllowedUses != nil {
+		in, out := &in.AllowedUses, &out.AllowedUses
+		*out = make([]IPPoolAllowedUse, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2641,6 +2641,21 @@ func schema_pkg_apis_projectcalico_v3_IPPoolSpec(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"allowedUses": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AllowedUse controls what the IP pool will be used for.  If not specified or empty, defaults to [\"Tunnel\", \"Workload\"] for back-compatibility",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"cidr"},
 			},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Allow admins to segregate IP pools by "use".  The available uses are:

* Workload IPs
* Tunnel IPs (for hosts)

Enterprise also supports additional values.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico IP pools now support an "allowedUses" field, which allows certain pools to be reserved for tunnel IPs and/or workloads. For back compatibility, the field defaults to allowing both workload and tunnel IPs.
```
