### PR TITLE
Automated cherry pick of #48: Add local Makefile for automated code updates

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -1,0 +1,24 @@
+# This is the local Makefile for the projectcalico/api repository, with targets
+# specific to github.com/projectcalico/api. This is opposed to Makefile, which
+# is mirrored from github.com/projectcalico/calico/api.
+
+# update pulls in the latest contents of this repository from the upstream
+# github.com/projectcalico/calico/api directory.
+CALICO_VERSION ?= $(shell git rev-parse --abbrev-ref HEAD)
+update: check-dirty
+	# Clone a temporary copy of the Calico repo at the given version.
+	rm -rf /tmp/calico-api-mirror
+	mkdir -p /tmp/calico-api-mirror
+	git clone --depth 1 git@github.com:projectcalico/calico.git -b $(CALICO_VERSION) /tmp/calico-api-mirror
+	# Remove local files - we'll add them back from the Calico repo's contents.
+	rm -r pkg/ build/ examples/ hack/
+	# Add in files from the Calico repo.
+	cp -r /tmp/calico-api-mirror/api/. .
+	cp /tmp/calico-api-mirror/lib.Makefile .
+	cp /tmp/calico-api-mirror/metadata.mk .
+	# Some files, we want to keep the local versions of. 
+	# For example, README content is different between the two locations.
+	git checkout Makefile.local README.md
+
+check-dirty:
+	git diff --quiet || echo "Repository has local changes" && exit 1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # projectcalico/api
 
-This is canonical source for API definitions of Projectcalico.
+This repository is a mirror of the canonical home for Calico API definitions.
+
+It is recommended to use this repository for projects which use the Calico API, so as to avoid importing the full Calico source code.
+
+To make changes to the Calico API, you must first submit a PR against [github.com/projectcalico/calico/api](https://github.com/projectcalico/calico).
+Once merged, changes will be mirrored to this repository for consumption.
 
 ## How to use
 


### PR DESCRIPTION
Cherry pick of #48 on release-v3.22.

#48: Add local Makefile for automated code updates

# Original PR Body below

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Adds a Makefile target to run which will mirror api code from the
source-of-truth in github.com/projectcalico/calico/api

For example:

```
make CALICO_VERSION=master update -f Makefile.local
```

Will submit a subsequent PR which actually runs the target. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```