### PR TITLE
Fix gen-files ordering: run openapi-gen before client-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,7 @@ gen-files .generate_files: lint-cache-dir clean-generated
 		--output-file zz_generated.deepcopy.go \
 		"$(PACKAGE_NAME)/pkg/apis/projectcalico/v3"'
 
-	# generate all pkg/client contents
-	$(DOCKER_RUN) $(CALICO_BUILD) \
-	   sh -c '$(GIT_CONFIG_SSH) $(BUILD_DIR)/update-client-gen.sh'
-
-	# generate openapi
+	# generate openapi (must run before client-gen, which uses it for --openapi-schema)
 	$(DOCKER_RUN) $(CALICO_BUILD) \
 	   sh -c '$(GIT_CONFIG_SSH) openapi-gen \
 		--v 1 --logtostderr \
@@ -88,6 +84,10 @@ gen-files .generate_files: lint-cache-dir clean-generated
 		"k8s.io/apimachinery/pkg/util/intstr" \
 		"k8s.io/apimachinery/pkg/version" \
 		"$(PACKAGE_NAME)/pkg/lib/numorstring"'
+
+	# generate all pkg/client contents
+	$(DOCKER_RUN) $(CALICO_BUILD) \
+	   sh -c '$(GIT_CONFIG_SSH) $(BUILD_DIR)/update-client-gen.sh'
 
 	touch .generate_files
 	$(MAKE) fix
@@ -116,7 +116,7 @@ clean-generated:
 	find $(TOP_SRC_DIRS) -name zz_generated* -exec rm {} \;
 	# rollback changes to the generated clientset directories
 	# find $(TOP_SRC_DIRS) -type d -name *_generated -exec rm -rf {} \;
-	rm -rf pkg/client/clientset_generated pkg/client/informers_generated pkg/client/listers_generated pkg/openapi
+	rm -rf pkg/client/clientset_generated pkg/client/informers_generated pkg/client/listers_generated pkg/client/applyconfiguration_generated pkg/openapi
 
 clean-bin:
 	rm -rf $(BINDIR) \

--- a/Makefile.local
+++ b/Makefile.local
@@ -108,7 +108,7 @@ pull-upstream-changes:
 
 	# Remove monorepo-only directories and files that don't belong in the
 	# standalone API repo. The bgpfilter_test.go file requires a kind cluster.
-	rm -rf config/ admission/ patches/
+	rm -rf config/ admission/
 	rm -f pkg/apis/projectcalico/v3/bgpfilter_test.go
 
 # Restores any files that we want to keep even if they're different


### PR DESCRIPTION
The updated `update-client-gen.sh` (synced from the monorepo) now uses `hack/openapi-schema/` which imports `pkg/openapi`. Two things were broken:

- **Makefile ordering**: `clean-generated` deletes `pkg/openapi`, so `openapi-gen` must run before `update-client-gen.sh` to regenerate it first. The standalone repo had them in the wrong order (the monorepo already has the correct order).
- **Missing patches**: `update-client-gen.sh` applies patches from `patches/`, but the sync was stripping that directory.

Also adds `pkg/client/applyconfiguration_generated` to the `clean-generated` target since the new client-gen script generates it.

Fixes the CI failure on https://github.com/projectcalico/api/pull/121.