### PR TITLE
Fix gen-files target on release-v3.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,7 @@ gen-files .generate_files: lint-cache-dir clean-generated
 		--output-file zz_generated.deepcopy.go \
 		"$(PACKAGE_NAME)/pkg/apis/projectcalico/v3"'
 
-	# generate all pkg/client contents
-	$(DOCKER_RUN) $(CALICO_BUILD) \
-	   sh -c '$(GIT_CONFIG_SSH) $(BUILD_DIR)/update-client-gen.sh'
-
-	# generate openapi
+	# generate openapi (must run before client-gen, which uses it for --openapi-schema)
 	$(DOCKER_RUN) $(CALICO_BUILD) \
 	   sh -c '$(GIT_CONFIG_SSH) openapi-gen \
 		--v 1 --logtostderr \
@@ -88,6 +84,10 @@ gen-files .generate_files: lint-cache-dir clean-generated
 		"k8s.io/apimachinery/pkg/util/intstr" \
 		"k8s.io/apimachinery/pkg/version" \
 		"$(PACKAGE_NAME)/pkg/lib/numorstring"'
+
+	# generate all pkg/client contents
+	$(DOCKER_RUN) $(CALICO_BUILD) \
+	   sh -c '$(GIT_CONFIG_SSH) $(BUILD_DIR)/update-client-gen.sh'
 
 	touch .generate_files
 	$(MAKE) fix
@@ -116,7 +116,7 @@ clean-generated:
 	find $(TOP_SRC_DIRS) -name zz_generated* -exec rm {} \;
 	# rollback changes to the generated clientset directories
 	# find $(TOP_SRC_DIRS) -type d -name *_generated -exec rm -rf {} \;
-	rm -rf pkg/client/clientset_generated pkg/client/informers_generated pkg/client/listers_generated pkg/openapi
+	rm -rf pkg/client/clientset_generated pkg/client/informers_generated pkg/client/listers_generated pkg/client/applyconfiguration_generated pkg/openapi
 
 clean-bin:
 	rm -rf $(BINDIR) \

--- a/Makefile.local
+++ b/Makefile.local
@@ -108,7 +108,7 @@ pull-upstream-changes:
 
 	# Remove monorepo-only directories and files that don't belong in the
 	# standalone API repo. The bgpfilter_test.go file requires a kind cluster.
-	rm -rf config/ admission/ patches/
+	rm -rf config/ admission/
 	rm -f pkg/apis/projectcalico/v3/bgpfilter_test.go
 
 # Restores any files that we want to keep even if they're different

--- a/patches/0002-Fix-duplicate-ensureProtoPort-method-in-FelixConfigurationSpec.patch
+++ b/patches/0002-Fix-duplicate-ensureProtoPort-method-in-FelixConfigurationSpec.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jiawei Huang <jiawei@tigera.io>
+Date: Thu, 13 Mar 2026 00:00:00 +0000
+Subject: [PATCH] Fix duplicate ensureProtoPort method in FelixConfigurationSpec
+
+applyconfiguration-gen generates an ensure helper named after the element type,
+not the field. When two fields share the same element type (*[]ProtoPort for
+FailsafeInboundHostPorts and FailsafeOutboundHostPorts), the helper is emitted
+twice, causing a compile error. Rename the second to be unique.
+---
+ api/pkg/client/applyconfiguration_generated/projectcalico/v3/felixconfigurationspec.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/api/pkg/client/applyconfiguration_generated/projectcalico/v3/felixconfigurationspec.go b/api/pkg/client/applyconfiguration_generated/projectcalico/v3/felixconfigurationspec.go
+--- a/api/pkg/client/applyconfiguration_generated/projectcalico/v3/felixconfigurationspec.go
++++ b/api/pkg/client/applyconfiguration_generated/projectcalico/v3/felixconfigurationspec.go
+@@ -1228,7 +1228,7 @@
+ 	return b
+ }
+
+-func (b *FelixConfigurationSpecApplyConfiguration) ensureProtoPortApplyConfigurationExists() {
++func (b *FelixConfigurationSpecApplyConfiguration) ensureOutboundProtoPortApplyConfigurationExists() {
+ 	if b.FailsafeOutboundHostPorts == nil {
+ 		b.FailsafeOutboundHostPorts = &[]ProtoPortApplyConfiguration{}
+ 	}
+@@ -1238,7 +1238,7 @@
+ // and returns the receiver, so that objects can be build by chaining "With" function invocations.
+ // If called multiple times, values provided by each call will be appended to the FailsafeOutboundHostPorts field.
+ func (b *FelixConfigurationSpecApplyConfiguration) WithFailsafeOutboundHostPorts(values ...*ProtoPortApplyConfiguration) *FelixConfigurationSpecApplyConfiguration {
+-	b.ensureProtoPortApplyConfigurationExists()
++	b.ensureOutboundProtoPortApplyConfigurationExists()
+ 	for i := range values {
+ 		if values[i] == nil {
+ 			panic("nil value passed to WithFailsafeOutboundHostPorts")
+--
+2.34.1
+

--- a/patches/0003-Fix-pointer-slice-append-in-IPAMBlockSpec-Allocations.patch
+++ b/patches/0003-Fix-pointer-slice-append-in-IPAMBlockSpec-Allocations.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jiawei Huang <jiawei@tigera.io>
+Date: Thu, 13 Mar 2026 00:00:00 +0000
+Subject: [PATCH] Fix pointer slice append in IPAMBlockSpec Allocations
+
+applyconfiguration-gen incorrectly dereferences pointer arguments for []*int
+fields. Allocations is []*int, so appending *values[i] produces an int, not
+*int. The fix is to append values[i] directly.
+
+TODO: This is the same []*int issue that 0001 works around for controller-gen.
+We should update applyconfiguration-gen to handle []*int properly itself.
+---
+ api/pkg/client/applyconfiguration_generated/projectcalico/v3/ipamblockspec.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/api/pkg/client/applyconfiguration_generated/projectcalico/v3/ipamblockspec.go b/api/pkg/client/applyconfiguration_generated/projectcalico/v3/ipamblockspec.go
+--- a/api/pkg/client/applyconfiguration_generated/projectcalico/v3/ipamblockspec.go
++++ b/api/pkg/client/applyconfiguration_generated/projectcalico/v3/ipamblockspec.go
+@@ -85,7 +85,7 @@
+ 		if values[i] == nil {
+ 			panic("nil value passed to WithAllocations")
+ 		}
+-		b.Allocations = append(b.Allocations, *values[i])
++		b.Allocations = append(b.Allocations, values[i])
+ 	}
+ 	return b
+ }
+--
+2.34.1
+


### PR DESCRIPTION
The Makefile had `openapi-gen` running after `update-client-gen.sh`, but the script imports `pkg/openapi` which `clean-generated` deletes before `gen-files` runs. This breaks CI on every PR to this branch.

- Reorder `openapi-gen` before `update-client-gen.sh` (matching the monorepo and api master)
- Add the `patches/` directory that `update-client-gen.sh` references (the sync was incorrectly stripping it)
- Stop removing `patches/` in `Makefile.local` so future syncs preserve it
- Add `applyconfiguration_generated` to `clean-generated` (matching master)

```release-note
None
```